### PR TITLE
Fix constant resolve issue in mruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ compiler:
 env:
   - MRUBY_VERSION=1.2.0
   - MRUBY_VERSION=master
-matrix:
-  allow_failures:
-    - env: MRUBY_VERSION=master
+# matrix:
+#   allow_failures:
+#     - env: MRUBY_VERSION=master
 branches:
   only:
     - master

--- a/mrblib/cgroupv2.rb
+++ b/mrblib/cgroupv2.rb
@@ -3,7 +3,7 @@ module CgroupV2
     attr_writer :mount_path, :root
 
     def new_group(name)
-      Group.new(name)
+      ::CgroupV2::Group.new(name)
     end
 
     def mount_path
@@ -11,7 +11,7 @@ module CgroupV2
     end
 
     def root
-      @__root ||= Group.new("/")
+      @__root ||= ::CgroupV2::Group.new("/")
     end
 
     def controllers


### PR DESCRIPTION
In current mruby head:

```ruby
module X
  class << self
     def y; Y; end
  end

  class Y
  end
end

X.y #=> ??
```

```
trace:
        [0] -:3:in #<Class:0x1048920>.y
        [1] -:10
-:3: uninitialized constant #<Class:X>::Y (NameError)
```

So using full-path to constants.